### PR TITLE
Add SkipTime and TakeTime operators

### DIFF
--- a/Runtime/Operators/Skip.cs
+++ b/Runtime/Operators/Skip.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright Edanoue, Inc. All Rights Reserved.
 
+#nullable enable
 using System;
 
 namespace Edanoue.Rx

--- a/Runtime/Operators/SkipTime.cs
+++ b/Runtime/Operators/SkipTime.cs
@@ -1,0 +1,104 @@
+﻿// Copyright Edanoue, Inc. All Rights Reserved.
+
+#nullable enable
+#if SUPPORT_TIME_PROVIDER
+using System;
+using System.Threading;
+using Edanoue.Rx.Internal;
+
+namespace Edanoue.Rx
+{
+    public static partial class ObservableExtensions
+    {
+        /// <summary>
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="duration"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Observable<T> Skip<T>(this Observable<T> source, TimeSpan duration)
+        {
+            return Skip(source, duration, ObservableSystem.DefaultTimeProvider);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="duration"></param>
+        /// <param name="timeProvider"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Observable<T> Skip<T>(this Observable<T> source, TimeSpan duration, TimeProvider timeProvider)
+        {
+            return new SkipTime<T>(source, duration.Normalize(), timeProvider);
+        }
+    }
+
+    internal sealed class SkipTime<T> : Observable<T>
+    {
+        private readonly TimeSpan      _duration;
+        private readonly Observable<T> _source;
+        private readonly TimeProvider  _timeProvider;
+
+        public SkipTime(Observable<T> source, TimeSpan duration, TimeProvider timeProvider)
+        {
+            _source = source;
+            _duration = duration;
+            _timeProvider = timeProvider;
+        }
+
+        protected override IDisposable SubscribeCore(Observer<T> observer)
+        {
+            return _source.Subscribe(new _SkipTime(observer, _duration, _timeProvider));
+        }
+
+        private sealed class _SkipTime : Observer<T>, IDisposable
+        {
+            private static readonly TimerCallback _timerCallback = TimerStopped;
+
+            private readonly Observer<T> _observer;
+            private          ITimer?     _timer; // when null, the timer has been stopped
+
+            public _SkipTime(Observer<T> observer, TimeSpan duration, TimeProvider timeProvider)
+            {
+                _observer = observer;
+                _timer = timeProvider.CreateStoppedTimer(_timerCallback, this);
+                _timer.InvokeOnce(duration);
+            }
+
+            protected override void OnNextCore(T value)
+            {
+                if (Volatile.Read(ref _timer) != null)
+                {
+                    return;
+                }
+
+                _observer.OnNext(value);
+            }
+
+            protected override void OnErrorResumeCore(Exception error)
+            {
+                _observer.OnErrorResume(error);
+            }
+
+            protected override void OnCompletedCore(Result result)
+            {
+                _observer.OnCompleted(result);
+            }
+
+            private static void TimerStopped(object? state)
+            {
+                var self = (_SkipTime)state!;
+                Volatile.Read(ref self._timer)?.Dispose();
+                Volatile.Write(ref self._timer, null);
+            }
+
+            protected override void DisposeCore()
+            {
+                Volatile.Read(ref _timer)?.Dispose();
+                Volatile.Write(ref _timer, null);
+            }
+        }
+    }
+}
+#endif

--- a/Runtime/Operators/SkipTime.cs.meta
+++ b/Runtime/Operators/SkipTime.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0e6c0030a2f84b9085a5927d92325d57
+timeCreated: 1709866196

--- a/Runtime/Operators/TakeTime.cs
+++ b/Runtime/Operators/TakeTime.cs
@@ -1,0 +1,107 @@
+﻿// Copyright Edanoue, Inc. All Rights Reserved.
+
+#nullable enable
+#if SUPPORT_TIME_PROVIDER
+using System;
+using System.Threading;
+using Edanoue.Rx.Internal;
+
+namespace Edanoue.Rx
+{
+    public static partial class ObservableExtensions
+    {
+        /// <summary>
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="duration"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Observable<T> Take<T>(this Observable<T> source, TimeSpan duration)
+        {
+            return Take(source, duration, ObservableSystem.DefaultTimeProvider);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="duration"></param>
+        /// <param name="timeProvider"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Observable<T> Take<T>(this Observable<T> source, TimeSpan duration, TimeProvider timeProvider)
+        {
+            return new TakeTime<T>(source, duration.Normalize(), timeProvider);
+        }
+    }
+
+    internal sealed class TakeTime<T> : Observable<T>
+    {
+        private readonly TimeSpan      _duration;
+        private readonly Observable<T> _source;
+        private readonly TimeProvider  _timeProvider;
+
+        public TakeTime(Observable<T> source, TimeSpan duration, TimeProvider timeProvider)
+        {
+            _source = source;
+            _duration = duration;
+            _timeProvider = timeProvider;
+        }
+
+        protected override IDisposable SubscribeCore(Observer<T> observer)
+        {
+            return _source.Subscribe(new _TakeTime(observer, _duration, _timeProvider));
+        }
+
+        private sealed class _TakeTime : Observer<T>, IDisposable
+        {
+            private static readonly TimerCallback _timerCallback = TimerStopped;
+            private readonly        object        _gate          = new();
+
+            private readonly Observer<T> _observer;
+            private readonly ITimer      _timer;
+
+            public _TakeTime(Observer<T> observer, TimeSpan duration, TimeProvider timeProvider)
+            {
+                _observer = observer;
+                _timer = timeProvider.CreateStoppedTimer(_timerCallback, this);
+                _timer.InvokeOnce(duration);
+            }
+
+            protected override void OnNextCore(T value)
+            {
+                lock (_gate)
+                {
+                    _observer.OnNext(value);
+                }
+            }
+
+            protected override void OnErrorResumeCore(Exception error)
+            {
+                lock (_gate)
+                {
+                    _observer.OnErrorResume(error);
+                }
+            }
+
+            protected override void OnCompletedCore(Result result)
+            {
+                lock (_gate)
+                {
+                    _observer.OnCompleted(result);
+                }
+            }
+
+            private static void TimerStopped(object? state)
+            {
+                var self = (_TakeTime)state!;
+                self.OnCompleted();
+            }
+
+            protected override void DisposeCore()
+            {
+                _timer.Dispose();
+            }
+        }
+    }
+}
+#endif

--- a/Runtime/Operators/TakeTime.cs.meta
+++ b/Runtime/Operators/TakeTime.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c4105fe72f5a431ab987798c556702e5
+timeCreated: 1709866281


### PR DESCRIPTION
Added two new time-related operators, SkipTime and TakeTime, to the Edanoue.React library. The SkipTime operator omits items emitted by an Observable for a specified time duration from the start. Conversely, the TakeTime operator only takes items emitted by an Observable for a specified time duration from the start.