### PR TITLE
Add Distinct and DistinctUntilChanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 ## Operators
 
 ### CombineLatest
+
 ```csharp
 var s1 = new Subject<int>();
 var s2 = new Subject<string>();
@@ -37,6 +38,70 @@ s2.OnNext(8); // > "4 8"
 
 > [!NOTE]
 > Factory 版との違いは任意の型を組み合わせ可能なのと, 次のストリームに流す合成用の関数 (Select のような) を渡せる点
+
+### Distinct
+
+```csharp
+var r = new List<int>();
+var s = new Subject<int>();
+s.Distinct().Subscribe(r.Add);
+
+s.OnNext(1); // > [1]
+s.OnNext(2); // > [1, 2]
+s.OnNext(1); // > [1, 2]
+s.OnNext(2); // > [1, 2]
+s.OnNext(3); // > [1, 2, 3]
+```
+
+- 一度登場した値は以降弾く
+
+### DistinctBy
+
+```csharp
+var r = new List<(string, int)>();
+var s = new Subject<(string, int)>();
+s.DistinctBy(static x => x.Item1).Subscribe(r.Add);
+
+s.OnNext(("foo", 1)); // > [("foo", 1)]
+s.OnNext(("bar", 2)); // > [("foo", 1), ("bar", 2)]
+s.OnNext(("foo", 3)); // > [("foo", 1), ("bar", 2)]
+s.OnNext(("bar", 4)); // > [("foo", 1), ("bar", 2)]
+s.OnNext(("baz", 5)); // > [("foo", 1), ("bar", 2), ("baz", 5)]
+```
+
+- Distinct の判定部分を任意の関数に変更できる
+
+### DistinctUntilChanged
+
+```csharp
+var r = new List<int>();
+var s = new Subject<int>();
+s.DistinctUntilChanged().Subscribe(r.Add);
+
+s.OnNext(1); // > [1]
+s.OnNext(2); // > [1, 2]
+s.OnNext(2); // > [1, 2]
+s.OnNext(1); // > [1, 2, 1]
+s.OnNext(2); // > [1, 2, 1, 2]
+```
+
+- 連続して登場した値は弾く
+
+### DistinctUntilChangedBy
+
+```csharp
+var r = new List<(string, int)>();
+var s = new Subject<(string, int)>();
+s.DistinctUntilChangedBy(static x => x.Item1).Subscribe(r.Add);
+
+s.OnNext(("foo", 1)); // > [("foo", 1)]
+s.OnNext(("bar", 2)); // > [("foo", 1), ("bar", 2)]
+s.OnNext(("bar", 3)); // > [("foo", 1), ("bar", 2)]
+s.OnNext(("foo", 4)); // > [("foo", 1), ("bar", 2), ("foo", 4)]
+s.OnNext(("bar", 5)); // > [("foo", 1), ("bar", 2), ("foo", 4), ("bar", 5)]
+```
+
+- DistinctUntilChanged の判定部分を任意の関数に変更できる
 
 ### Select
 
@@ -164,6 +229,9 @@ s2.Dispose(); // isCompleted: true
 ```
 
 ## TimeProvider dependent operators
+
+> [!NOTE]
+> 現在は Unity 内の Time ではなく, System の Time を使用している
 
 ### Debounce
 

--- a/Runtime/Operators/Distinct.cs.meta
+++ b/Runtime/Operators/Distinct.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c9afabfc7318f00498ab03f3ba834ad5

--- a/Runtime/Operators/DistinctBy.cs.meta
+++ b/Runtime/Operators/DistinctBy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c38b2d65aaf4549428c4ee1fb540b5d8

--- a/Runtime/Operators/DistinctUntilChanged.cs
+++ b/Runtime/Operators/DistinctUntilChanged.cs
@@ -1,0 +1,73 @@
+﻿// Copyright Edanoue, Inc. All Rights Reserved.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Edanoue.Rx
+{
+    public static partial class ObservableExtensions
+    {
+        public static Observable<T> DistinctUntilChanged<T>(this Observable<T> source)
+        {
+            return DistinctUntilChanged(source, EqualityComparer<T>.Default);
+        }
+
+        public static Observable<T> DistinctUntilChanged<T>(this Observable<T> source, IEqualityComparer<T> comparer)
+        {
+            return new DistinctUntilChanged<T>(source, comparer);
+        }
+    }
+
+    internal sealed class DistinctUntilChanged<T> : Observable<T>
+    {
+        private readonly IEqualityComparer<T> _comparer;
+        private readonly Observable<T>        _source;
+
+        public DistinctUntilChanged(Observable<T> source, IEqualityComparer<T> comparer)
+        {
+            _source = source;
+            _comparer = comparer;
+        }
+
+        protected override IDisposable SubscribeCore(Observer<T> observer)
+        {
+            return _source.Subscribe(new _DistinctUntilChanged(observer, _comparer));
+        }
+
+        private sealed class _DistinctUntilChanged : Observer<T>
+        {
+            private readonly IEqualityComparer<T> _comparer;
+            private readonly Observer<T>          _observer;
+            private          bool                 _hasValue;
+            private          T?                   _lastValue;
+
+            public _DistinctUntilChanged(Observer<T> observer, IEqualityComparer<T> comparer)
+            {
+                _observer = observer;
+                _comparer = comparer;
+            }
+
+            protected override void OnNextCore(T value)
+            {
+                if (!_hasValue || !_comparer.Equals(_lastValue!, value))
+                {
+                    _hasValue = true;
+                    _lastValue = value;
+                    _observer.OnNext(value);
+                }
+            }
+
+            protected override void OnErrorResumeCore(Exception error)
+            {
+                _observer.OnErrorResume(error);
+            }
+
+            protected override void OnCompletedCore(Result result)
+            {
+                _observer.OnCompleted(result);
+            }
+        }
+    }
+}

--- a/Runtime/Operators/DistinctUntilChanged.cs.meta
+++ b/Runtime/Operators/DistinctUntilChanged.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5bfa01a8de614d37ae30abf618408736
+timeCreated: 1710315386

--- a/Runtime/Operators/DistinctUntilChangedBy.cs
+++ b/Runtime/Operators/DistinctUntilChangedBy.cs
@@ -1,0 +1,81 @@
+﻿// Copyright Edanoue, Inc. All Rights Reserved.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Edanoue.Rx
+{
+    public static partial class ObservableExtensions
+    {
+        public static Observable<T> DistinctUntilChangedBy<T, TKey>(this Observable<T> source,
+            Func<T, TKey> keySelector)
+        {
+            return DistinctUntilChangedBy(source, keySelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static Observable<T> DistinctUntilChangedBy<T, TKey>(this Observable<T> source,
+            Func<T, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            return new DistinctUntilChangedBy<T, TKey>(source, keySelector, comparer);
+        }
+    }
+
+    internal sealed class DistinctUntilChangedBy<T, TKey> : Observable<T>
+    {
+        private readonly IEqualityComparer<TKey> _comparer;
+        private readonly Func<T, TKey>           _keySelector;
+        private readonly Observable<T>           _source;
+
+        public DistinctUntilChangedBy(Observable<T> source, Func<T, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            _source = source;
+            _keySelector = keySelector;
+            _comparer = comparer;
+        }
+
+        protected override IDisposable SubscribeCore(Observer<T> observer)
+        {
+            return _source.Subscribe(new _DistinctUntilChangedBy(observer, _keySelector, _comparer));
+        }
+
+        private sealed class _DistinctUntilChangedBy : Observer<T>
+        {
+            private readonly IEqualityComparer<TKey> _comparer;
+            private readonly Func<T, TKey>           _keySelector;
+            private readonly Observer<T>             _observer;
+            private          bool                    _hasValue;
+            private          TKey?                   _lastKey;
+
+            public _DistinctUntilChangedBy(Observer<T> observer, Func<T, TKey> keySelector,
+                IEqualityComparer<TKey> comparer)
+            {
+                _observer = observer;
+                _keySelector = keySelector;
+                _comparer = comparer;
+            }
+
+            protected override void OnNextCore(T value)
+            {
+                var key = _keySelector(value);
+                if (!_hasValue || !_comparer.Equals(_lastKey!, key))
+                {
+                    _hasValue = true;
+                    _lastKey = key;
+                    _observer.OnNext(value);
+                }
+            }
+
+            protected override void OnErrorResumeCore(Exception error)
+            {
+                _observer.OnErrorResume(error);
+            }
+
+            protected override void OnCompletedCore(Result result)
+            {
+                _observer.OnCompleted(result);
+            }
+        }
+    }
+}

--- a/Runtime/Operators/DistinctUntilChangedBy.cs.meta
+++ b/Runtime/Operators/DistinctUntilChangedBy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b4b7d2f9df09425695999fb0c80a50ef
+timeCreated: 1710315602

--- a/Tests/Editor/Operator/TS_Distinct.cs
+++ b/Tests/Editor/Operator/TS_Distinct.cs
@@ -1,0 +1,30 @@
+﻿// Copyright Edanoue, Inc. All Rights Reserved.
+
+#nullable enable
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Edanoue.Rx
+{
+    public sealed class TS_Distinct
+    {
+        [Test]
+        public void Distinct()
+        {
+            var source = new Subject<int>();
+            var result = new List<int>();
+
+            using var list = source.Distinct().Subscribe(result.Add);
+
+            source.OnNext(1);
+            source.OnNext(2);
+            source.OnNext(3);
+            source.OnNext(1);
+            source.OnNext(2);
+            source.OnNext(3);
+            source.OnNext(4);
+
+            CollectionAssert.AreEqual(result, new[] { 1, 2, 3, 4 });
+        }
+    }
+}

--- a/Tests/Editor/Operator/TS_Distinct.cs.meta
+++ b/Tests/Editor/Operator/TS_Distinct.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ecd92c9cf8814c2ca871a0559dfd5418
+timeCreated: 1710315086

--- a/Tests/Editor/Operator/TS_DistinctBy.cs
+++ b/Tests/Editor/Operator/TS_DistinctBy.cs
@@ -1,0 +1,30 @@
+﻿// Copyright Edanoue, Inc. All Rights Reserved.
+
+#nullable enable
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Edanoue.Rx
+{
+    public sealed class TS_DistinctBy
+    {
+        [Test]
+        public void DistinctBy()
+        {
+            var source = new Subject<(int, int)>();
+            var result = new List<(int, int)>();
+
+            using var list = source.DistinctBy(static x => x.Item1).Subscribe(result.Add);
+
+            source.OnNext((1, 10));
+            source.OnNext((2, 20));
+            source.OnNext((3, 30));
+            source.OnNext((1, 100));
+            source.OnNext((2, 200));
+            source.OnNext((3, 300));
+            source.OnNext((4, 400));
+
+            CollectionAssert.AreEqual(result, new[] { (1, 10), (2, 20), (3, 30), (4, 400) });
+        }
+    }
+}

--- a/Tests/Editor/Operator/TS_DistinctBy.cs.meta
+++ b/Tests/Editor/Operator/TS_DistinctBy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2429396fd10a4b008b90730d0373adfa
+timeCreated: 1710315237

--- a/Tests/Editor/Operator/TS_DistinctUntilChanged.cs
+++ b/Tests/Editor/Operator/TS_DistinctUntilChanged.cs
@@ -1,0 +1,29 @@
+﻿// Copyright Edanoue, Inc. All Rights Reserved.
+
+#nullable enable
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Edanoue.Rx
+{
+    public sealed class TS_DistinctUntilChanged
+    {
+        [Test]
+        public void DistinctUntilChanged()
+        {
+            var source = new Subject<int>();
+            var result = new List<int>();
+
+            using var list = source.DistinctUntilChanged().Subscribe(result.Add);
+
+            source.OnNext(1);
+            source.OnNext(2);
+            source.OnNext(3);
+            source.OnNext(3);
+            source.OnNext(2);
+            source.OnNext(1);
+
+            CollectionAssert.AreEqual(result, new[] { 1, 2, 3, 2, 1 });
+        }
+    }
+}

--- a/Tests/Editor/Operator/TS_DistinctUntilChanged.cs.meta
+++ b/Tests/Editor/Operator/TS_DistinctUntilChanged.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cc38bf17074848dd91c796b9f966e4f8
+timeCreated: 1710315724

--- a/Tests/Editor/Operator/TS_DistinctUntilChangedBy.cs
+++ b/Tests/Editor/Operator/TS_DistinctUntilChangedBy.cs
@@ -1,0 +1,29 @@
+﻿// Copyright Edanoue, Inc. All Rights Reserved.
+
+#nullable enable
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Edanoue.Rx
+{
+    public sealed class TS_DistinctUntilChangedBy
+    {
+        [Test]
+        public void DistinctUntilChangedBy()
+        {
+            var source = new Subject<(int, int)>();
+            var result = new List<(int, int)>();
+
+            using var list = source.DistinctUntilChangedBy(static x => x.Item1).Subscribe(result.Add);
+
+            source.OnNext((1, 10));
+            source.OnNext((2, 20));
+            source.OnNext((3, 30));
+            source.OnNext((3, 300));
+            source.OnNext((2, 200));
+            source.OnNext((1, 100));
+
+            CollectionAssert.AreEqual(result, new[] { (1, 10), (2, 20), (3, 30), (2, 200), (1, 100) });
+        }
+    }
+}

--- a/Tests/Editor/Operator/TS_DistinctUntilChangedBy.cs.meta
+++ b/Tests/Editor/Operator/TS_DistinctUntilChangedBy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5717b2d455bf4efa8ded78cb99e24c69
+timeCreated: 1710315776


### PR DESCRIPTION
Implemented two functions: 'Distinct' and 'DistinctUntilChanged', along with their 'By' counterparts that allow for customized key selection. Additionally, created corresponding unit tests for these new functions. Also updated the README.md to provide usage examples and descriptions for each function.